### PR TITLE
[codex] fix init-config script path

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "start": "next start -p ${PORT:-3000}",
     "lint": "next lint",
-    "init-config": "node src/scripts/exportManualData.js"
+    "init-config": "node src/scripts/exportManualData.mjs"
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",


### PR DESCRIPTION
## Summary
- point `npm run init-config` at the existing `exportManualData.mjs` script

## Root cause
The package script referenced `src/scripts/exportManualData.js`, but the repository only contains `src/scripts/exportManualData.mjs`, so the command failed with `MODULE_NOT_FOUND`.

## Validation
- `npm run init-config`
- `git diff --check`